### PR TITLE
Surpress warning messages when needed

### DIFF
--- a/parallax/__init__.py
+++ b/parallax/__init__.py
@@ -98,6 +98,7 @@ class Options(object):
     default_user = None          # User to connect as (unless overridden per host)
     recursive = True             # (copy, slurp only) Copy recursively
     localdir = None              # (slurp only) Local base directory to copy to
+    warn_message = True          # show warn message when asking for a password
 
 
 def _expand_host_port_user(lst):
@@ -169,6 +170,7 @@ def call(hosts, cmdline, opts=Options()):
                       askpass=opts.askpass,
                       outdir=opts.outdir,
                       errdir=opts.errdir,
+                      warn_message=opts.warn_message,
                       callbacks=_CallOutputBuilder())
     for host, port, user in _expand_host_port_user(hosts):
         cmd = _build_call_cmd(host, port, user, cmdline,
@@ -245,6 +247,7 @@ def copy(hosts, src, dst, opts=Options()):
                       askpass=opts.askpass,
                       outdir=opts.outdir,
                       errdir=opts.errdir,
+                      warn_message=opts.warn_message,
                       callbacks=_CopyOutputBuilder())
     for host, port, user in _expand_host_port_user(hosts):
         cmd = _build_copy_cmd(host, port, user, src, dst, opts)
@@ -340,6 +343,7 @@ def slurp(hosts, src, dst, opts=Options()):
                       askpass=opts.askpass,
                       outdir=opts.outdir,
                       errdir=opts.errdir,
+                      warn_message=opts.warn_message,
                       callbacks=_SlurpOutputBuilder(localdirs))
     for host, port, user in _expand_host_port_user(hosts):
         localpath = localdirs[host]

--- a/parallax/askpass_server.py
+++ b/parallax/askpass_server.py
@@ -26,15 +26,16 @@ class PasswordServer(object):
         self.buffermap = {}
         self.password = ""
 
-    def start(self, iomap, backlog):
+    def start(self, iomap, backlog, warn=True):
         """Prompts for the password, creates a socket, and starts listening.
 
         The specified backlog should be the max number of clients connecting
         at once.
         """
-        message = ('Warning: do not enter your password if anyone else has'
-                   ' superuser privileges or access to your account.')
-        print(textwrap.fill(message))
+        if warn:
+            message = ('Warning: do not enter your password if anyone else has'
+                       ' superuser privileges or access to your account.')
+            print(textwrap.fill(message))
 
         self.password = getpass.getpass()
 

--- a/parallax/manager.py
+++ b/parallax/manager.py
@@ -44,6 +44,7 @@ class Manager(object):
                  askpass=False,
                  outdir=None,
                  errdir=None,
+                 warn_message=True,
                  callbacks=DefaultCallbacks()):
         # Backwards compatibility with old __init__
         # format: Only argument is an options dict
@@ -86,6 +87,7 @@ class Manager(object):
         self.done = []
 
         self.askpass_socket = None
+        self.warn_message = warn_message
 
     def run(self):
         """Processes tasks previously added with add_task."""
@@ -99,7 +101,7 @@ class Manager(object):
 
             if self.askpass:
                 pass_server = PasswordServer()
-                pass_server.start(self.iomap, self.limit)
+                pass_server.start(self.iomap, self.limit, warn=self.warn_message)
                 self.askpass_socket = pass_server.address
 
             self.set_sigchld_handler()


### PR DESCRIPTION
Hi @krig ,

I want to add `warn_message` option, which default value is `True`, means if this option is `False`,
warning message
```
message = ('Warning: do not enter your password if anyone else has'
                   ' superuser privileges or access to your account.')
```
will not be shown when asking for a password.
What do you think about this?

Regards,
xin