### PR TITLE
Replace preexec_fn as start_new_session

### DIFF
--- a/parallax/task.py
+++ b/parallax/task.py
@@ -19,6 +19,9 @@ except NameError:
     bytes = str
 
 
+PY2 = sys.version[0] == '2'
+
+
 class Task(object):
     """Starts a process and manages its input and output.
 
@@ -118,8 +121,13 @@ class Task(object):
 
         # Create the subprocess.  Since we carefully call set_cloexec() on
         # all open files, we specify close_fds=False.
-        self.proc = Popen(self.cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE,
-                          close_fds=False, preexec_fn=os.setsid, env=environ)
+        if PY2:
+            self.proc = Popen(self.cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE, 
+                    close_fds=False, preexec_fn=os.setsid, env=environ)
+        else:
+            self.proc = Popen(self.cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE,
+                    close_fds=False, start_new_session=True, env=environ)
+
         self.timestamp = time.time()
         if self.inputbuffer:
             self.stdin = self.proc.stdin


### PR DESCRIPTION
Hi @krig,

As mentioned in https://docs.python.org/3/library/subprocess.html:
```
Note If you need to modify the environment for the child use the env parameter 
rather than doing it in a preexec_fn. The start_new_session parameter can take 
the place of a previously common use of preexec_fn to call os.setsid() in the child.
```
And
```
Changed in version 3.8: The preexec_fn parameter is no longer supported in subinterpreters.
 The use of the parameter in a subinterpreter raises RuntimeError.
```

I think it's time to replace `preexec_fn` as `start_new_session`