### PR TITLE
No need to mask signals for subprocess call

### DIFF
--- a/parallax/manager.py
+++ b/parallax/manager.py
@@ -163,24 +163,13 @@ class Manager(object):
 
     def update_tasks(self, writer):
         """Reaps tasks and starts as many new ones as allowed."""
-        # Mask signals to work around a Python bug:
-        #   http://bugs.python.org/issue1068268
-        # Since sigprocmask isn't in the stdlib, clear the SIGCHLD handler.
-        # Since signals are masked, reap_tasks needs to be called once for
-        # each loop.
         keep_running = True
         while keep_running:
-            self.clear_sigchld_handler()
             self._start_tasks_once(writer)
-            self.set_sigchld_handler()
             keep_running = self.reap_tasks()
 
     def _start_tasks_once(self, writer):
-        """Starts tasks once.
-
-        Due to http://bugs.python.org/issue1068268, signals must be masked
-        when this method is called.
-        """
+        """Starts tasks once."""
         while self.tasks and len(self.running) < self.limit:
             task = self.tasks.pop(0)
             self.running.append(task)


### PR DESCRIPTION
Hi @krig ,

I use parallax a lot in configuring qdevice and crmsh functional testing.

#### Problem
I found that parallax will raise `TypeError` with a certain probability, like this:
```
ERROR:Step:Run "crm cluster join -c hanode1 -i eth0 -y" on "hanode2":
Failed on hanode2: Exited with error code 1, Error output: Traceback (most recent call last):
  File "/usr/bin/crm", line 46, in <module>
    rc = main.run()
  File "/usr/lib/python3.8/site-packages/crmsh/main.py", line 370, in run
    return main_input_loop(context, user_args)
  File "/usr/lib/python3.8/site-packages/crmsh/main.py", line 249, in main_input_loop
    rc = handle_noninteractive_use(context, user_args)
  File "/usr/lib/python3.8/site-packages/crmsh/main.py", line 205, in handle_noninteractive_use
    if context.run(' '.join(l)):
  File "/usr/lib/python3.8/site-packages/crmsh/ui_context.py", line 86, in run
    rv = self.execute_command() is not False
  File "/usr/lib/python3.8/site-packages/crmsh/ui_context.py", line 276, in execute_command
    rv = self.command_info.function(*arglist)
  File "/usr/lib/python3.8/site-packages/crmsh/ui_cluster.py", line 348, in do_join
    bootstrap.bootstrap_join(join_context)
  File "/usr/lib/python3.8/site-packages/crmsh/bootstrap.py", line 2331, in bootstrap_join
    join_ssh_merge(cluster_node)
  File "/usr/lib/python3.8/site-packages/crmsh/bootstrap.py", line 1788, in join_ssh_merge
    results = parallax.call(hosts, cat_cmd, opts)
  File "/usr/lib/python3.8/site-packages/parallax/__init__.py", line 189, in call
    return manager.run()
  File "/usr/lib/python3.8/site-packages/parallax/manager.py", line 117, in run
    self.update_tasks(writer)
  File "/usr/lib/python3.8/site-packages/parallax/manager.py", line 173, in update_tasks
    self.clear_sigchld_handler()
  File "/usr/lib/python3.8/site-packages/parallax/manager.py", line 136, in clear_sigchld_handler
    signal.signal(signal.SIGCHLD, signal.SIG_DFL)
  File "/usr/lib64/python3.8/signal.py", line 47, in signal
    handler = _signal.signal(_enum_to_int(signalnum), _enum_to_int(handler))
TypeError: 'int' object is not callable
``` 
#### How to reproduce
To reproduce, I prepare 4 nodes(salt1, salt2, salt3, salt4; all use latest Tumbleweed; configured with password-less ssh login)
On each node, has `/opt/exec1.sh`:
```
s_time=`/usr/bin/expr $RANDOM % 4`
s_time=1.$s_time
sleep $s_time
echo "done after $s_time seconds"
```
And on `salt1`, has `test1.py`
```
import sys
from crmsh import parallax

hosts = ["salt1", "salt2", "salt3", "salt4"]
cmd = "sh /opt/exec1.sh"

try:
    res = parallax.parallax_call(hosts, cmd)
except TypeError:
    sys.exit(8)
```
On salt1, has `run.sh`:
```
for i in {1..20}  #number can be changed
do
  for m in {1..200} #number can be changed
  do
    echo "$i:$m"
    python3 test1.py
    rt="$?"
    if [ "$rt" -eq 8 ];then
      touch "type_error_on_${i}_${m}"
      break
    elif [ "$rt" -ne 0 ];then
      touch "other_error_on_${i}_${m}"
      break
    fi
  done
done
```
Run `sh run.sh` to start testing.

I found parallax will probably raise `TypeError` 7-8 times while looping 1000 times. 

#### Solution
I found in source code, `update_tasks` method in manager.py calling `self.clear_sigchld_handler` is to work around python bug [subprocess is not EINTR-safe](https://bugs.python.org/issue1068268), which had already fixed for years.
So I decided to remove `self.clear_sigchld_handler` and `self.set_sigchld_handler` calling and related comments.

When I use above test script to test with more than 28000 times, no `TypeError` happened anymore,
except several `ValueError` caused by ssh connection timeout(in crmsh, I give default timeout `10s`, now I changed it as `20s`, so far so good)