### PR TITLE
Dev: add parallax.run() to return non-zero rc without raising exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,17 @@ Share and enjoy!
 
   Executes the given command on a set of hosts, collecting the output.
 
-  Returns a dict mapping the hostname of
-  each host either to a tuple containing a return code,
-  stdout and stderr, or an `parallax.Error` instance
-  describing the error.
+  Returns a dict mapping the hostname of each host either to a tuple containing
+  a return code, stdout and stderr when return code is 0, or an `parallax.Error`
+  instance describing the error when return code is not 0.
+
+* `parallax.run(hosts, cmdline, opts)`
+
+  Executes the given command on a set of hosts, collecting the output.
+
+  Returns a dict mapping the hostname of each host either to a tuple containing
+  a return code, stdout and stderr, or an `parallax.Error` instance describing
+  the error when ssh error occurred.
 
 * `parallax.copy(hosts, src, dst, opts)`
 

--- a/parallax/__init__.py
+++ b/parallax/__init__.py
@@ -55,14 +55,14 @@ def to_ascii(s):
         return s
 
 
-class Error(BaseException):
+class Error(Exception):
     """
     Returned instead of a result for a host
     in case of an error during the processing for
     that host.
     """
     def __init__(self, msg, task):
-        super(BaseException, self).__init__()
+        super(Exception, self).__init__()
         self.msg = msg
         self.task = task
 


### PR DESCRIPTION
# Problem

Sometimes when a command is executed, it is expected that it may fail and user is interested in its return code. For example, using `test -f` to figure out whether a file exists. In such cases, non-zero return code should not be treated as errors.

# Solution

1. A new interface `parallax.run()` is added to implement this behaviour.
2. Also fix `parallax.Error`: A user-defined exception should usually be derived from `Exception`.