### PR TITLE
Fix: manager: writer thread can only be started once

### DIFF
--- a/parallax/manager.py
+++ b/parallax/manager.py
@@ -98,8 +98,6 @@ class Manager(object):
             writer = None
 
         try:
-            if writer:
-                writer.start()
             if self.askpass:
                 pass_server = PasswordServer()
                 pass_server.start(self.iomap, self.limit, warn=self.warn_message)


### PR DESCRIPTION
This fixes the issue reported in ClusterLabs/crmsh#1134.